### PR TITLE
Code cleanup

### DIFF
--- a/src/Mdns.csproj
+++ b/src/Mdns.csproj
@@ -32,7 +32,6 @@
 
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />
-    <PackageReference Include="IPNetwork2" Version="2.1.2" />
     <PackageReference Include="Makaretu.Dns" Version="2.0.1" />
   </ItemGroup>
 

--- a/src/MulticastClient.cs
+++ b/src/MulticastClient.cs
@@ -17,7 +17,7 @@ namespace Makaretu.Dns
     /// </summary>
     class MulticastClient : IDisposable
     {
-        static readonly ILog log = LogManager.GetLogger(typeof(MulticastClient));
+        private static readonly ILog log = LogManager.GetLogger(typeof(MulticastClient));
 
         /// <summary>
         ///   The port number assigned to Multicast DNS.
@@ -27,13 +27,13 @@ namespace Makaretu.Dns
         /// </value>
         public static readonly int MulticastPort = 5353;
 
-        static readonly IPAddress MulticastAddressIp4 = IPAddress.Parse("224.0.0.251");
-        static readonly IPAddress MulticastAddressIp6 = IPAddress.Parse("FF02::FB");
-        static readonly IPEndPoint MdnsEndpointIp6 = new IPEndPoint(MulticastAddressIp6, MulticastPort);
-        static readonly IPEndPoint MdnsEndpointIp4 = new IPEndPoint(MulticastAddressIp4, MulticastPort);
+        private static readonly IPAddress MulticastAddressIp4 = IPAddress.Parse("224.0.0.251");
+        private static readonly IPAddress MulticastAddressIp6 = IPAddress.Parse("FF02::FB");
+        private static readonly IPEndPoint MdnsEndpointIp6 = new IPEndPoint(MulticastAddressIp6, MulticastPort);
+        private static readonly IPEndPoint MdnsEndpointIp4 = new IPEndPoint(MulticastAddressIp4, MulticastPort);
 
-        readonly List<UdpClient> receivers;
-        readonly ConcurrentDictionary<IPAddress, UdpClient> senders = new ConcurrentDictionary<IPAddress, UdpClient>();
+        private readonly List<UdpClient> receivers;
+        private readonly ConcurrentDictionary<IPAddress, UdpClient> senders = new ConcurrentDictionary<IPAddress, UdpClient>();
 
         public event EventHandler<UdpReceiveResult> MessageReceived;
 
@@ -116,7 +116,7 @@ namespace Makaretu.Dns
 
                     receivers.Add(sender);
 
-                    log.Debug($"Will send via {localEndpoint}");
+                    log.Debug($"Will send via {localEndpoint}"); 
                     if (!senders.TryAdd(address, sender)) // Should not fail
                     {
                         sender.Dispose();
@@ -161,7 +161,7 @@ namespace Makaretu.Dns
             }
         }
 
-        void Listen(UdpClient receiver)
+        private void Listen(UdpClient receiver)
         {
             // ReceiveAsync does not support cancellation.  So the receiver is disposed
             // to stop it. See https://github.com/dotnet/corefx/issues/9848
@@ -184,7 +184,7 @@ namespace Makaretu.Dns
             });
         }
 
-        IEnumerable<IPAddress> GetNetworkInterfaceLocalAddresses(NetworkInterface nic)
+        private IEnumerable<IPAddress> GetNetworkInterfaceLocalAddresses(NetworkInterface nic)
         {
             return nic
                 .GetIPProperties()

--- a/src/MulticastClient.cs
+++ b/src/MulticastClient.cs
@@ -114,6 +114,8 @@ namespace Makaretu.Dns
                             throw new NotSupportedException($"Address family {address.AddressFamily}.");
                     }
 
+                    receivers.Add(sender);
+
                     log.Debug($"Will send via {localEndpoint}");
                     if (!senders.TryAdd(address, sender)) // Should not fail
                     {

--- a/src/MulticastClient.cs
+++ b/src/MulticastClient.cs
@@ -219,20 +219,7 @@ namespace Makaretu.Dns
                     }
                     receivers.Clear();
 
-                    foreach (var address in senders.Keys)
-                    {
-                        if (senders.TryRemove(address, out var sender))
-                        {
-                            try
-                            {
-                                sender.Dispose();
-                            }
-                            catch
-                            {
-                                // eat it.
-                            }
-                        }
-                    }
+                    // senders are a subset of reiceivers (listening for answers to unicast queries), so no need to dispose this list.
                     senders.Clear();
                 }
 

--- a/src/NetworkInterfaceEventArgs.cs
+++ b/src/NetworkInterfaceEventArgs.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.NetworkInformation;
-using System.Text;
+
 
 namespace Makaretu.Dns
 {

--- a/src/RecentMessages.cs
+++ b/src/RecentMessages.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
 
 namespace Makaretu.Dns
 {

--- a/src/ServiceDiscovery.cs
+++ b/src/ServiceDiscovery.cs
@@ -14,9 +14,10 @@ namespace Makaretu.Dns
     /// <seealso href="https://tools.ietf.org/html/rfc6763">RFC 6763 DNS-Based Service Discovery</seealso>
     public class ServiceDiscovery : IDisposable
     {
-        static readonly ILog log = LogManager.GetLogger(typeof(ServiceDiscovery));
-        static readonly DomainName LocalDomain = new DomainName("local");
-        static readonly DomainName SubName = new DomainName("_sub");
+        private static readonly ILog log = LogManager.GetLogger(typeof(ServiceDiscovery));
+
+        private static readonly DomainName LocalDomain = new DomainName("local");
+        private static readonly DomainName SubName = new DomainName("_sub");
 
         /// <summary>
         ///   The service discovery service name.
@@ -26,8 +27,8 @@ namespace Makaretu.Dns
         /// </value>
         public static readonly DomainName ServiceName = new DomainName("_services._dns-sd._udp.local");
 
-        readonly bool ownsMdns;
-        List<ServiceProfile> profiles = new List<ServiceProfile>();
+        private readonly bool ownsMdns;
+        private readonly List<ServiceProfile> profiles = new List<ServiceProfile>();
 
         /// <summary>
         ///   Creates a new instance of the <see cref="ServiceDiscovery"/> class.
@@ -322,7 +323,7 @@ namespace Makaretu.Dns
             profiles.ForEach(profile => Unadvertise(profile));
         }
 
-        void OnAnswer(object sender, MessageEventArgs e)
+        private void OnAnswer(object sender, MessageEventArgs e)
         {
             var msg = e.Message;
             if (log.IsDebugEnabled)
@@ -366,7 +367,7 @@ namespace Makaretu.Dns
             }
         }
 
-        void OnQuery(object sender, MessageEventArgs e)
+        private void OnQuery(object sender, MessageEventArgs e)
         {
             var request = e.Message;
 

--- a/src/ServiceInstanceDiscoveryEventArgs.cs
+++ b/src/ServiceInstanceDiscoveryEventArgs.cs
@@ -1,7 +1,4 @@
-﻿using Makaretu.Dns;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿
 
 namespace Makaretu.Dns
 {

--- a/src/ServiceInstanceShutdownEventArgs.cs
+++ b/src/ServiceInstanceShutdownEventArgs.cs
@@ -1,8 +1,4 @@
-﻿using Makaretu.Dns;
-using System;
-using System.Collections.Generic;
-using System.Text;
-
+﻿
 namespace Makaretu.Dns
 {
     /// <summary>

--- a/src/ServiceProfile.cs
+++ b/src/ServiceProfile.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Sockets;
-using System.Text;
 
 namespace Makaretu.Dns
 {


### PR DESCRIPTION
Mostly removing unneccessary namespace usage, adding access modifiers.

Also removed one useless line of code which pulled in IPNetwork2 package dependency:
`
static readonly IPNetwork[] LinkLocalNetworks = new[] { IPNetwork.Parse("169.254.0.0/16"), IPNetwork.Parse("fe80::/10") };
`

LinkLocalNetworks is never used or referenced anywhere.